### PR TITLE
Add issue template: some checkboxes and labels with strikethrough hints

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+This issue is about 
++ [ ] Course
++ [ ] Event
++ [ ] Project
++ [ ] Other
+By/for
++ [ ] kottans
++ [ ] non-kottans
+
+Subject: ~~short sentence describing initiative~~
+Term/duration: ~~when is it going to take place or how long it might last~~
+Keywords: ~~online/offline, city, technologies~~
+What do we propose and what do we need to reach the goal.


### PR DESCRIPTION
I believe after creation people would be able to check corresponding checkboxes?